### PR TITLE
Add Panache entity classes for remaining models

### DIFF
--- a/src/main/java/org/example/entities/Depot.java
+++ b/src/main/java/org/example/entities/Depot.java
@@ -1,0 +1,28 @@
+package org.example.entities;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.*;
+import java.util.List;
+
+@Entity
+@Table(name = "Depot")
+public class Depot extends PanacheEntityBase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "depotID")
+    public Integer id;
+
+    @Column(name = "depotName", length = 50, nullable = false)
+    public String depotName;
+
+    @Column(name = "depotSortID")
+    public Integer depotSortId;
+
+    @ManyToOne
+    @JoinColumn(name = "locationFK")
+    public Location location;
+
+    @OneToMany(mappedBy = "depot")
+    public List<Driver> drivers;
+}

--- a/src/main/java/org/example/entities/DriveArea.java
+++ b/src/main/java/org/example/entities/DriveArea.java
@@ -1,0 +1,21 @@
+package org.example.entities;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.*;
+import java.util.List;
+
+@Entity
+@Table(name = "DriveArea")
+public class DriveArea extends PanacheEntityBase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "driveareaID")
+    public Integer id;
+
+    @Column(name = "driveareaName", length = 50, nullable = false)
+    public String driveareaName;
+
+    @OneToMany(mappedBy = "driveArea")
+    public List<RouteDriverArea> routeDriverAreas;
+}

--- a/src/main/java/org/example/entities/Driver.java
+++ b/src/main/java/org/example/entities/Driver.java
@@ -50,7 +50,17 @@ public class Driver extends PanacheEntityBase {
     @JoinColumn(name = "companyFK")
     public Company company;
 
-    // additional relations (Depot, Service, Location) would go here
+    @ManyToOne
+    @JoinColumn(name = "depotFK")
+    public Depot depot;
+
+    @ManyToOne
+    @JoinColumn(name = "serviceFK")
+    public Service service;
+
+    @ManyToOne
+    @JoinColumn(name = "locationIDFK")
+    public Location location;
 
     @Column(name = "shuntservice")
     public Boolean shuntservice;
@@ -83,4 +93,10 @@ public class Driver extends PanacheEntityBase {
 
     @OneToMany(mappedBy = "driver")
     public List<DriverFiles> driverFiles;
+
+    @OneToMany(mappedBy = "driver")
+    public List<RouteDriver> routeDrivers;
+
+    @OneToMany(mappedBy = "driver")
+    public List<VehicleDriver> vehicleDrivers;
 }

--- a/src/main/java/org/example/entities/Location.java
+++ b/src/main/java/org/example/entities/Location.java
@@ -1,0 +1,30 @@
+package org.example.entities;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.*;
+import java.util.List;
+
+@Entity
+@Table(name = "Location")
+public class Location extends PanacheEntityBase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "locationID")
+    public Integer id;
+
+    @Column(name = "locationName", length = 50, nullable = false)
+    public String locationName;
+
+    @Column(name = "locationToken", length = 50, nullable = false)
+    public String locationToken;
+
+    @OneToMany(mappedBy = "location")
+    public List<Depot> depots;
+
+    @OneToMany(mappedBy = "location")
+    public List<Driver> drivers;
+
+    @OneToMany(mappedBy = "location")
+    public List<LocationVehicle> locationVehicles;
+}

--- a/src/main/java/org/example/entities/LocationVehicle.java
+++ b/src/main/java/org/example/entities/LocationVehicle.java
@@ -1,0 +1,26 @@
+package org.example.entities;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "Location-VehicleHT")
+public class LocationVehicle extends PanacheEntityBase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "vehicleSetID")
+    public Integer id;
+
+    @ManyToOne
+    @JoinColumn(name = "locationIDFK")
+    public Location location;
+
+    @ManyToOne
+    @JoinColumn(name = "vehicletypeIDFK")
+    public VehicleTypes vehicleType;
+
+    @ManyToOne
+    @JoinColumn(name = "vehicleSubtypeIDFK")
+    public VehicleSubtype vehicleSubtype;
+}

--- a/src/main/java/org/example/entities/Route.java
+++ b/src/main/java/org/example/entities/Route.java
@@ -1,0 +1,27 @@
+package org.example.entities;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.*;
+import java.util.List;
+
+@Entity
+@Table(name = "Routes")
+public class Route extends PanacheEntityBase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "routeID")
+    public Integer id;
+
+    @Column(name = "routeName", length = 50)
+    public String routeName;
+
+    @Column(name = "routeSortID")
+    public Integer routeSortId;
+
+    @OneToMany(mappedBy = "route")
+    public List<RouteDriverArea> routeDriverAreas;
+
+    @OneToMany(mappedBy = "route")
+    public List<RouteDriver> routeDrivers;
+}

--- a/src/main/java/org/example/entities/RouteDriver.java
+++ b/src/main/java/org/example/entities/RouteDriver.java
@@ -1,0 +1,29 @@
+package org.example.entities;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.*;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "Route-DriverHT")
+public class RouteDriver extends PanacheEntityBase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "routeDriverID")
+    public Integer id;
+
+    @ManyToOne
+    @JoinColumn(name = "routeIDFK")
+    public Route route;
+
+    @ManyToOne
+    @JoinColumn(name = "driverIDFK")
+    public Driver driver;
+
+    @Column(name = "routeDate")
+    public LocalDate routeDate;
+
+    @Column(name = "driverRouteSortID")
+    public Integer driverRouteSortId;
+}

--- a/src/main/java/org/example/entities/RouteDriverArea.java
+++ b/src/main/java/org/example/entities/RouteDriverArea.java
@@ -1,0 +1,21 @@
+package org.example.entities;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "Routes-DriverAreaHT")
+public class RouteDriverArea extends PanacheEntityBase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Integer id;
+
+    @ManyToOne
+    @JoinColumn(name = "routesIDFK")
+    public Route route;
+
+    @ManyToOne
+    @JoinColumn(name = "driverareaIDFK")
+    public DriveArea driveArea;
+}

--- a/src/main/java/org/example/entities/Service.java
+++ b/src/main/java/org/example/entities/Service.java
@@ -1,0 +1,24 @@
+package org.example.entities;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.*;
+import java.util.List;
+
+@Entity
+@Table(name = "Service")
+public class Service extends PanacheEntityBase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "serviceID")
+    public Integer id;
+
+    @Column(name = "serviceName", length = 50, nullable = false)
+    public String serviceName;
+
+    @Column(name = "serviceSortID")
+    public Integer serviceSortId;
+
+    @OneToMany(mappedBy = "service")
+    public List<Driver> drivers;
+}

--- a/src/main/java/org/example/entities/VehicleDriver.java
+++ b/src/main/java/org/example/entities/VehicleDriver.java
@@ -1,0 +1,21 @@
+package org.example.entities;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "Vehicle-DriverHT")
+public class VehicleDriver extends PanacheEntityBase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Integer id;
+
+    @ManyToOne
+    @JoinColumn(name = "vehicletypeIDFK")
+    public VehicleTypes vehicleType;
+
+    @ManyToOne
+    @JoinColumn(name = "driverIDFK")
+    public Driver driver;
+}

--- a/src/main/java/org/example/entities/VehicleSubtype.java
+++ b/src/main/java/org/example/entities/VehicleSubtype.java
@@ -1,0 +1,21 @@
+package org.example.entities;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.*;
+import java.util.List;
+
+@Entity
+@Table(name = "VehicleSubtype")
+public class VehicleSubtype extends PanacheEntityBase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "vehicleSubtypeID")
+    public Integer id;
+
+    @Column(name = "vehicleSubtypeName", length = 50, nullable = false)
+    public String vehicleSubtypeName;
+
+    @OneToMany(mappedBy = "vehicleSubtype")
+    public List<LocationVehicle> locationVehicles;
+}

--- a/src/main/java/org/example/entities/VehicleTypes.java
+++ b/src/main/java/org/example/entities/VehicleTypes.java
@@ -1,0 +1,27 @@
+package org.example.entities;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.*;
+import java.util.List;
+
+@Entity
+@Table(name = "Vehicletypes")
+public class VehicleTypes extends PanacheEntityBase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "vehicletypeID")
+    public Integer id;
+
+    @Column(name = "vehicletypeName", length = 50, nullable = false)
+    public String vehicleName;
+
+    @Column(name = "vehicletypeSortID")
+    public Integer vehicleSortId;
+
+    @OneToMany(mappedBy = "vehicleType")
+    public List<LocationVehicle> locationVehicles;
+
+    @OneToMany(mappedBy = "vehicleType")
+    public List<VehicleDriver> vehicleDrivers;
+}


### PR DESCRIPTION
## Summary
- implement remaining Panache entity classes: Depot, DriveArea, Location, LocationVehicle, RouteDriver, Route, RouteDriverArea, Service, VehicleDriver, VehicleSubtype, VehicleTypes
- update `Driver` entity to reference Depot, Service and Location and expose RouteDriver and VehicleDriver collections

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685b2c02644883299d860322badacfe5