### PR TITLE
Add query filtering and sorting utilities

### DIFF
--- a/src/main/java/org/example/resources/CompanyResource.java
+++ b/src/main/java/org/example/resources/CompanyResource.java
@@ -2,11 +2,16 @@ package org.example.resources;
 
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.example.entities.Company;
+import org.example.util.QueryOptions;
+import org.example.util.QueryUtils;
+import io.quarkus.hibernate.orm.panache.Panache;
 
 import java.util.List;
 
@@ -17,10 +22,10 @@ import java.util.List;
 public class CompanyResource {
 
     @GET
-    @Operation(summary = "Retrieve a paginated list of companies")
-    public List<Company> getAll(@QueryParam("skip") @DefaultValue("0") int skip,
-                               @QueryParam("take") @DefaultValue("10") int take) {
-        return Company.findAll().range(skip, skip + take - 1).list();
+    @Operation(summary = "Retrieve a paginated list of companies with optional filtering and sorting")
+    public List<Company> getAll(@Context UriInfo uriInfo) {
+        QueryOptions options = QueryUtils.from(uriInfo.getQueryParameters(), "id", 10);
+        return QueryUtils.find(Panache.getEntityManager(), Company.class, options);
     }
 
     @GET

--- a/src/main/java/org/example/resources/DriverFileResource.java
+++ b/src/main/java/org/example/resources/DriverFileResource.java
@@ -2,11 +2,16 @@ package org.example.resources;
 
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.example.entities.DriverFiles;
+import org.example.util.QueryOptions;
+import org.example.util.QueryUtils;
+import io.quarkus.hibernate.orm.panache.Panache;
 
 import java.util.List;
 
@@ -17,10 +22,10 @@ import java.util.List;
 public class DriverFileResource {
 
     @GET
-    @Operation(summary = "Retrieve all driver file entries")
-    public List<DriverFiles> getAll(@QueryParam("skip") @DefaultValue("0") int skip,
-                                    @QueryParam("take") @DefaultValue("10") int take) {
-        return DriverFiles.findAll().range(skip, skip + take - 1).list();
+    @Operation(summary = "Retrieve all driver file entries with optional filtering and sorting")
+    public List<DriverFiles> getAll(@Context UriInfo uriInfo) {
+        QueryOptions options = QueryUtils.from(uriInfo.getQueryParameters(), "id", 10);
+        return QueryUtils.find(Panache.getEntityManager(), DriverFiles.class, options);
     }
 
     @GET

--- a/src/main/java/org/example/resources/DriverResource.java
+++ b/src/main/java/org/example/resources/DriverResource.java
@@ -2,11 +2,16 @@ package org.example.resources;
 
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.example.entities.Driver;
+import org.example.util.QueryOptions;
+import org.example.util.QueryUtils;
+import io.quarkus.hibernate.orm.panache.Panache;
 
 import java.util.List;
 
@@ -17,10 +22,10 @@ import java.util.List;
 public class DriverResource {
 
     @GET
-    @Operation(summary = "Retrieve a paginated list of drivers")
-    public List<Driver> getAll(@QueryParam("skip") @DefaultValue("0") int skip,
-                               @QueryParam("take") @DefaultValue("10") int take) {
-        return Driver.findAll().range(skip, skip + take - 1).list();
+    @Operation(summary = "Retrieve a paginated list of drivers with optional filtering and sorting")
+    public List<Driver> getAll(@Context UriInfo uriInfo) {
+        QueryOptions options = QueryUtils.from(uriInfo.getQueryParameters(), "id", 10);
+        return QueryUtils.find(Panache.getEntityManager(), Driver.class, options);
     }
 
     @GET

--- a/src/main/java/org/example/util/QueryFilter.java
+++ b/src/main/java/org/example/util/QueryFilter.java
@@ -1,0 +1,13 @@
+package org.example.util;
+
+public class QueryFilter {
+    public final String field;
+    public final String operator;
+    public final Object value;
+
+    public QueryFilter(String field, String operator, Object value) {
+        this.field = field;
+        this.operator = operator;
+        this.value = value;
+    }
+}

--- a/src/main/java/org/example/util/QueryOptions.java
+++ b/src/main/java/org/example/util/QueryOptions.java
@@ -1,0 +1,12 @@
+package org.example.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class QueryOptions {
+    public int skip;
+    public int take;
+    public String sortField;
+    public String sortOrder;
+    public List<QueryFilter> filters = new ArrayList<>();
+}

--- a/src/main/java/org/example/util/QueryUtils.java
+++ b/src/main/java/org/example/util/QueryUtils.java
@@ -1,0 +1,114 @@
+package org.example.util;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
+import jakarta.ws.rs.core.MultivaluedMap;
+
+import java.util.*;
+
+public class QueryUtils {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    public static QueryOptions from(MultivaluedMap<String, String> params, String defaultSortField, int defaultTake) {
+        QueryOptions options = new QueryOptions();
+        options.skip = parseInt(params.getFirst("skip"), 0);
+        options.take = parseInt(params.getFirst("take"), defaultTake);
+
+        String sortField = params.getFirst("sortField");
+        options.sortField = (sortField != null && !sortField.isBlank()) ? sortField : defaultSortField;
+        String sortOrder = params.getFirst("sortOrder");
+        options.sortOrder = "-1".equals(sortOrder) ? "desc" : "asc";
+
+        String fParam = params.getFirst("f");
+        if (fParam != null && !fParam.isBlank()) {
+            options.filters = parseFilters(fParam);
+        }
+        return options;
+    }
+
+    private static int parseInt(String str, int def) {
+        try {
+            return str != null ? Integer.parseInt(str) : def;
+        } catch (Exception e) {
+            return def;
+        }
+    }
+
+    private static List<QueryFilter> parseFilters(String json) {
+        try {
+            Map<String, Object> map = mapper.readValue(json, new TypeReference<Map<String, Object>>() {});
+            List<QueryFilter> list = new ArrayList<>();
+            for (Map.Entry<String, Object> e : map.entrySet()) {
+                String path = e.getKey().replace('_', '.');
+                Object val = e.getValue();
+                if (val instanceof List<?> arr && arr.size() >= 2) {
+                    list.add(new QueryFilter(path, arr.get(0).toString(), arr.get(1)));
+                } else {
+                    list.add(new QueryFilter(path, "=", val));
+                }
+            }
+            return list;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid JSON in parameter `f`", e);
+        }
+    }
+
+    public static <T> List<T> find(EntityManager em, Class<T> entityClass, QueryOptions options) {
+        StringBuilder jpql = new StringBuilder("select e from " + entityClass.getSimpleName() + " e");
+        Map<String, Object> params = new HashMap<>();
+        if (!options.filters.isEmpty()) {
+            jpql.append(" where ");
+            int idx = 0;
+            for (QueryFilter f : options.filters) {
+                if (idx > 0) jpql.append(" and ");
+                String param = "p" + idx;
+                buildCondition(jpql, f, param, params);
+                idx++;
+            }
+        }
+        if (options.sortField != null && !options.sortField.isBlank()) {
+            jpql.append(" order by e.").append(options.sortField.replace('_', '.')).append(' ').append(options.sortOrder);
+        }
+
+        jakarta.persistence.Query query = em.createQuery(jpql.toString(), entityClass);
+        for (var entry : params.entrySet()) {
+            query.setParameter(entry.getKey(), entry.getValue());
+        }
+        query.setFirstResult(options.skip);
+        query.setMaxResults(options.take);
+        return query.getResultList();
+    }
+
+    private static void buildCondition(StringBuilder jpql, QueryFilter f, String paramName, Map<String, Object> params) {
+        String fieldPath = "e." + f.field;
+        switch (f.operator) {
+            case "=":
+                jpql.append(fieldPath).append(" = :").append(paramName);
+                params.put(paramName, f.value);
+                break;
+            case "!=":
+                jpql.append(fieldPath).append(" <> :").append(paramName);
+                params.put(paramName, f.value);
+                break;
+            case ">":
+            case ">=":
+            case "<":
+            case "<=":
+                jpql.append(fieldPath).append(' ').append(f.operator).append(" :").append(paramName);
+                params.put(paramName, f.value);
+                break;
+            case "%%":
+                jpql.append("lower(").append(fieldPath).append(") like :").append(paramName);
+                params.put(paramName, "%" + f.value.toString().toLowerCase() + "%");
+                break;
+            case "!%":
+                jpql.append("lower(").append(fieldPath).append(") not like :").append(paramName);
+                params.put(paramName, "%" + f.value.toString().toLowerCase() + "%");
+                break;
+            default:
+                throw new IllegalArgumentException("Operator \"" + f.operator + "\" for field \"" + f.field + "\" not supported.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a small query utility that parses filter JSON and builds JPQL
- expose new `QueryUtils` via resources for Drivers, Companies and DriverFiles
- support pagination, sorting and filtering for all resources

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b2d2ca8e88329b315394b45de1353